### PR TITLE
Improvements for testing multi-version application:

### DIFF
--- a/nanotest/pom.xml
+++ b/nanotest/pom.xml
@@ -78,6 +78,12 @@
             <artifactId>junit</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.tobedevoured.naether</groupId>
+            <artifactId>core</artifactId>
+            <version>0.13.5</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -106,6 +112,16 @@
                         </goals>
                         <configuration>
                             <artifact>org.gridkit.lab:viconcurrent:0.7.15</artifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jmock-junit-2.2.1</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>get</goal>
+                        </goals>
+                        <configuration>
+                            <artifact>org.jmock:jmock-junit4:2.5.1</artifact>
                         </configuration>
                     </execution>
                 </executions>

--- a/nanotest/src/main/java/org/gridkit/nanocloud/test/maven/MavenClasspathConfig.java
+++ b/nanotest/src/main/java/org/gridkit/nanocloud/test/maven/MavenClasspathConfig.java
@@ -1,7 +1,16 @@
 package org.gridkit.nanocloud.test.maven;
 
+import com.tobedevoured.naether.api.Naether;
+import com.tobedevoured.naether.impl.NaetherImpl;
+import org.apache.maven.model.Dependency;
+import org.gridkit.nanocloud.VX;
 import org.gridkit.vicluster.ViConfigurable;
 import org.gridkit.vicluster.ViConfExtender;
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.repository.RemoteRepository;
+
+import java.net.URL;
+import java.util.Set;
 
 public class MavenClasspathConfig extends ViConfigurable.Delegate {
 
@@ -47,4 +56,26 @@ public class MavenClasspathConfig extends ViConfigurable.Delegate {
 		MavenClasspathManager.removeArtifactVersion(getConfigurable(), groupId, artifactId);
 		return this;
 	}
+
+    public MavenClasspathConfig addWithTransitive(String groupId, String artifactId, String version) throws Exception {
+        return addWithTransitive(groupId, artifactId, version, null);
+    }
+
+    public MavenClasspathConfig addWithTransitive(String groupId, String artifactId, String version, Set<RemoteRepository> remoteRepositories) throws Exception {
+        Naether naether = new NaetherImpl();
+        if (remoteRepositories != null) {
+            naether.setRemoteRepositories(remoteRepositories);
+        }
+        final Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion(version);
+        naether.addDependency(dependency);
+        naether.resolveDependencies();
+        for (org.sonatype.aether.graph.Dependency resolvedDependency : naether.currentDependencies()) {
+            final Artifact artifact = resolvedDependency.getArtifact();
+            add(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
+        }
+        return this;
+    }
 }

--- a/vicluster-core/src/main/java/org/gridkit/vicluster/ViConf.java
+++ b/vicluster-core/src/main/java/org/gridkit/vicluster/ViConf.java
@@ -59,6 +59,8 @@ public class ViConf extends GenericConfig implements ViSpiConfig {
 
 	public static final String CLASSPATH_TWEAK = "classpath:tweak:";
 
+    public static final String INHERIT_CLASS_PATH = "classpath:inherit:";
+
 	public static final String REMOTE_HOST = "remote:host";
 	public static final String REMOTE_ACCOUNT = "remote:account";
 	public static final String REMOTE_HOST_CONFIG = "remote:host-config";
@@ -501,6 +503,11 @@ public class ViConf extends GenericConfig implements ViSpiConfig {
 		public ClasspathConf remove(String ruleName, String path) {
 			return remove(ruleName, pathToURL(path));
 		}
+
+        public ClasspathConf inheritClasspath(boolean inherit){
+            conf.setProp(INHERIT_CLASS_PATH, ""+inherit);
+            return this;
+        }
 
 		private String defaultName(URL url) {
 			String name;


### PR DESCRIPTION
1) .x(CLASSPATH).inheritClasspath(false) - to skip classpath from test (all but gridkit classes and test-classes. Test-classes should not be skipped because it contains runnables that should be invoked on remote side)
2) .x(MAVEN).addWithTransitive(...) - to add artifact to classpath including transitive dependencies.
