### PR TITLE
correctly handle NoDefClassFound in user's classes.

### DIFF
--- a/nanocloud/src/test/java/org/gridkit/nanocloud/CentOS_RemoteNodeFeatureTest.java
+++ b/nanocloud/src/test/java/org/gridkit/nanocloud/CentOS_RemoteNodeFeatureTest.java
@@ -102,6 +102,12 @@ public class CentOS_RemoteNodeFeatureTest extends ViNodeFeatureTest {
 
     @Test
     @Override
+    public void test_handle_NoDefClassFound(){
+        super.test_handle_NoDefClassFound();
+    }
+
+    @Test
+    @Override
     public void test_inherit_cp_true() throws IOException, URISyntaxException {
         super.test_inherit_cp_true();
     }

--- a/nanocloud/src/test/java/org/gridkit/nanocloud/FreeBSD_RemoteNodeFeatureTest.java
+++ b/nanocloud/src/test/java/org/gridkit/nanocloud/FreeBSD_RemoteNodeFeatureTest.java
@@ -102,6 +102,12 @@ public class FreeBSD_RemoteNodeFeatureTest extends ViNodeFeatureTest {
 
     @Test
     @Override
+    public void test_handle_NoDefClassFound(){
+        super.test_handle_NoDefClassFound();
+    }
+
+    @Test
+    @Override
     public void test_inherit_cp_true() throws IOException, URISyntaxException {
         super.test_inherit_cp_true();
     }

--- a/nanocloud/src/test/java/org/gridkit/nanocloud/IsolateNodeFeatureTest.java
+++ b/nanocloud/src/test/java/org/gridkit/nanocloud/IsolateNodeFeatureTest.java
@@ -86,6 +86,12 @@ public class IsolateNodeFeatureTest extends ViNodeFeatureTest {
     }
 
 	@Test
+	@Override
+	public void test_handle_NoDefClassFound(){
+		super.test_handle_NoDefClassFound();
+	}
+
+	@Test
     @Override
     public void test_inherit_cp_true() throws IOException, URISyntaxException {
         super.test_inherit_cp_true();

--- a/nanocloud/src/test/java/org/gridkit/nanocloud/LocalNodeFeatureTest.java
+++ b/nanocloud/src/test/java/org/gridkit/nanocloud/LocalNodeFeatureTest.java
@@ -90,6 +90,12 @@ public class LocalNodeFeatureTest extends ViNodeFeatureTest {
 
     @Test
     @Override
+    public void test_handle_NoDefClassFound(){
+        super.test_handle_NoDefClassFound();
+    }
+
+    @Test
+    @Override
     public void test_inherit_cp_true() throws IOException, URISyntaxException {
         super.test_inherit_cp_true();
     }

--- a/nanocloud/src/test/java/org/gridkit/nanocloud/ViNodeFeatureTest.java
+++ b/nanocloud/src/test/java/org/gridkit/nanocloud/ViNodeFeatureTest.java
@@ -49,6 +49,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
+import org.junit.runners.JUnit4;
 
 public abstract class ViNodeFeatureTest {
 
@@ -380,6 +381,26 @@ public abstract class ViNodeFeatureTest {
         catch(Error e) {
             assertThat(e).isInstanceOf(NoClassDefFoundError.class);
         }
+	}
+
+	public void test_handle_NoDefClassFound(){
+		ViNode node = testNode();
+
+		node.x(CLASSPATH).inheritClasspath(false);
+
+		try {
+			node.exec(new Runnable() {
+				Assert anAssert = new Assert(){}; // NoClassDefFoundError during deserialization
+
+				@Override
+				public void run() {
+				}
+			});
+			Assert.fail("Exception is expected");
+		}
+		catch(Error e) {
+			assertThat(e).isInstanceOf(NoClassDefFoundError.class);
+		}
 	}
 
 	public void test_inherit_cp_true() throws IOException, URISyntaxException {

--- a/nanocloud/src/test/java/org/gridkit/nanocloud/viengine/Engine2_LocalNodeFeatureTest.java
+++ b/nanocloud/src/test/java/org/gridkit/nanocloud/viengine/Engine2_LocalNodeFeatureTest.java
@@ -82,6 +82,12 @@ public class Engine2_LocalNodeFeatureTest extends ViNodeFeatureTest {
 
     @Test
     @Override
+    public void test_handle_NoDefClassFound(){
+        super.test_handle_NoDefClassFound();
+    }
+
+    @Test
+    @Override
     public void test_inherit_cp_true() throws IOException, URISyntaxException {
         super.test_inherit_cp_true();
     }

--- a/zerormi/src/main/java/org/gridkit/zerormi/IOHelper.java
+++ b/zerormi/src/main/java/org/gridkit/zerormi/IOHelper.java
@@ -21,7 +21,7 @@ import java.net.SocketException;
 
 class IOHelper {
 	
-	public static boolean isSocketTerminationException(Exception e) {
+	public static boolean isSocketTerminationException(Throwable e) {
 		if (e instanceof EOFException) {
 			return true;
 		}

--- a/zerormi/src/main/java/org/gridkit/zerormi/ObjectOrException.java
+++ b/zerormi/src/main/java/org/gridkit/zerormi/ObjectOrException.java
@@ -1,0 +1,57 @@
+package org.gridkit.zerormi;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+
+public class ObjectOrException<T> implements Serializable {
+    private static final long serialVersionUID = 42L;
+
+    private T object;
+    private Throwable exceptionWhileReadObject;
+
+    public ObjectOrException(T object) {
+        this.object = object;
+    }
+
+    public T getObject() throws Throwable {
+        if (exceptionWhileReadObject != null) {
+            throw exceptionWhileReadObject;
+        } else {
+            return object;
+        }
+    }
+
+    private void writeObject(java.io.ObjectOutputStream outputStream) throws IOException {
+        RmiGateway.RmiObjectOutputStream out = (RmiGateway.RmiObjectOutputStream) outputStream;
+        out.writeObject(serializeToBytes(object, out));
+    }
+
+    private void readObject(java.io.ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
+        RmiGateway.RmiObjectInputStream in = (RmiGateway.RmiObjectInputStream) inputStream;
+        try {
+            object = deserializeFromBytes((byte[]) in.readObject(), in);
+        } catch (Throwable t) {
+            exceptionWhileReadObject = t;
+        }
+    }
+
+    private byte[] serializeToBytes(T object, RmiGateway.RmiObjectOutputStream prototype) throws IOException {
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        final RmiGateway.RmiObjectOutputStream out =
+                new RmiGateway.RmiObjectOutputStream(prototype.getName(), prototype.getChannel(), byteArrayOutputStream);
+        out.writeObject(object);
+        out.flush();
+        return byteArrayOutputStream.toByteArray();
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private T deserializeFromBytes(byte[] data, RmiGateway.RmiObjectInputStream prototype) throws IOException, ClassNotFoundException {
+        final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(data);
+        final RmiGateway.RmiObjectInputStream in =
+                new RmiGateway.RmiObjectInputStream(prototype.getName(), prototype.getChannel(), byteArrayInputStream);
+        return (T) in.readObject();
+    }
+}

--- a/zerormi/src/main/java/org/gridkit/zerormi/RemoteCall.java
+++ b/zerormi/src/main/java/org/gridkit/zerormi/RemoteCall.java
@@ -15,6 +15,9 @@
  */
 package org.gridkit.zerormi;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.Serializable;
 
 /**
@@ -28,26 +31,31 @@ public class RemoteCall implements RemoteMessage, Serializable {
 	/**
 	 * Instance will receive the call
 	 */
-	RemoteInstance remoteInstance;
+	private RemoteInstance remoteInstance;
 	
 	/**
 	 * Method's name
 	 * TODO normal method signature
 	 */
-	RemoteMethodSignature method;
+	private RemoteMethodSignature method;
 	
 	/**
 	 * Method's arguments
 	 */
-	Object[] args;
+	private ObjectOrException<Object[]> args;
+
+	/**
+	 * If exception was thrown while trying to deserialize arguments
+	 */
+	private Throwable exceptionWhileReadArgs = null;
 	
 	/**
 	 * The id is a number unique in client and server to identify the call
 	 */
-	Long callId;
+	private Long callId;
 
-	public Object[] getArgs() {
-		return args;
+	public Object[] getArgs() throws Throwable {
+		return args.getObject();
 	}
 
 	public Long getCallId() {
@@ -65,7 +73,7 @@ public class RemoteCall implements RemoteMessage, Serializable {
 	public RemoteCall(RemoteInstance remoteInstance, RemoteMethodSignature method, Object[] args, Long callId) {
 		this.remoteInstance = remoteInstance;
 		this.method = method;
-		this.args = args;
+		this.args = new ObjectOrException<Object[]>(args);;
 		this.callId = callId;
 	}
 

--- a/zerormi/src/main/java/org/gridkit/zerormi/RemoteReturn.java
+++ b/zerormi/src/main/java/org/gridkit/zerormi/RemoteReturn.java
@@ -26,24 +26,24 @@ public class RemoteReturn implements RemoteMessage {
 	/**
 	 * The return is a throwable to be thrown?
 	 */
-	boolean throwing;
+	private boolean throwing;
 	
 	/**
 	 * Returning object
 	 */
-	Object ret;
+	private ObjectOrException<Object> ret;
 	
 	/**
 	 * Call id which generated this return
 	 */
-	long callId;
+	private long callId;
 
 	public long getCallId() {
 		return callId;
 	}
 
-	public Object getRet() {
-		return ret;
+	public Object getRet() throws Throwable {
+		return ret.getObject();
 	}
 
 	public boolean isThrowing() {
@@ -52,7 +52,7 @@ public class RemoteReturn implements RemoteMessage {
 
 	public RemoteReturn(boolean throwing, Object ret, long callId) {
 		this.throwing = throwing;
-		this.ret = ret;
+		this.ret = new ObjectOrException<Object>(ret);
 		this.callId = callId;
 	}
 }

--- a/zerormi/src/main/java/org/gridkit/zerormi/hub/RemotingEndPoint.java
+++ b/zerormi/src/main/java/org/gridkit/zerormi/hub/RemotingEndPoint.java
@@ -192,7 +192,7 @@ public class RemotingEndPoint implements Runnable, RmiGateway.StreamErrorHandler
 	}
 
 	@Override
-	public void streamError(DuplexStream socket, Object stream, Exception error) {
+	public void streamError(DuplexStream socket, Object stream, Throwable error) {
 		LWARN.log("Slave read error: " + error.toString());
 		synchronized(pingSingnal) {
 			pingSingnal.notifyAll();

--- a/zerormi/src/main/java/org/gridkit/zerormi/hub/RemotingHub.java
+++ b/zerormi/src/main/java/org/gridkit/zerormi/hub/RemotingHub.java
@@ -205,7 +205,7 @@ public class RemotingHub implements MasterHub {
 		private DuplexStream stream;
 
 		@Override
-		public synchronized void streamError(DuplexStream socket, Object stream, Exception error) {
+		public synchronized void streamError(DuplexStream socket, Object stream, Throwable error) {
 			gateway.disconnect();
 			this.stream = null;
 			listener.interrupted(socket);


### PR DESCRIPTION
With `node.x(CLASSPATH).inheritClasspath(false)` there can be various Errors (NoDefClassFound, LinkageError, ClassCastException) during deserializing `RemoteCall`.
This pull request introduce soft handling of such errors - Throwables will be sent back to client, streams will not be terminated, nodes will not be killed.