### PR TITLE
add root package "" to allow spring-data-jpa fallback to default package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.0.6</version>
+                <version>1.2.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/vicluster-core/pom.xml
+++ b/vicluster-core/pom.xml
@@ -100,9 +100,16 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>3.2.17.RELEASE</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>2.5.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.200</version>
             <scope>test</scope>
         </dependency>
         


### PR DESCRIPTION
Sometimes we need specify unexisting package for @EntityScan. 
In our case it is done in base maven module and dependent modules may have and may don't have specified package (depends on  jpa usage). 
Spring-data-jpa fallbacks to default package if specified package does not exists. Probably it is not best behavior for spring-boot but it works in this way.
This PR adds root "" jar package that can be found as ResourceLoader.getResource("classpath:") 